### PR TITLE
Update controller no longer requires owner authentication

### DIFF
--- a/app/controllers/products.js
+++ b/app/controllers/products.js
@@ -65,6 +65,6 @@ module.exports = controller({
 }, { before: [
   { method: setUser, only: ['index', 'show'] },
   { method: authenticate, except: ['index', 'show'] },
-  { method: setModel(Product), only: ['show'] },
-  { method: setModel(Product, { forUser: true }), only: ['update', 'destroy'] }
+  { method: setModel(Product), only: ['show', 'update'] },
+  { method: setModel(Product, { forUser: true }), only: ['destroy'] }
 ] })


### PR DESCRIPTION
By simply moving 'update' from the authenticated setModel to the one above
which does not require authentication, we can now update products without
being the owner who created them.